### PR TITLE
Reload Vue template when CSS modules change in the <style> attribute

### DIFF
--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -344,7 +344,6 @@ const hotCompile = Meteor.bindEnvironment(function hotCompile(filePath, inputFil
 
       if (compileResult.cssModules) {
         cssModulesHash = Hash(JSON.stringify(compileResult.cssModules));
-        console.log('css modules hash', cssModulesHash)
       }
     }
   }


### PR DESCRIPTION
When using CSS modules, a change to the class names causes a change to the `$style` computed property and therefore requires the template to be reloaded in order to take effect. 
For example, if I create the following style, reference it in my template, and save my changes, `$style.foo` won't exist on the client after the hot refresh because the client won't know that it needs to reload the entire compiled JS instead of just reloading the render function.

``` html
<style module>
.foo {
 color: red;
}
</style>

<template>
<div :class="$style.foo"></div>
</template>
```

This PR adds cache-checking for the CSS modules output.