### PR TITLE
Enable loading of .vue files from npm packages

### DIFF
--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -153,11 +153,22 @@ VueComponentCompiler = class VueCompo extends CachingCompiler {
 
     const { js, templateHash } = generateJs(vueId, inputFile, compileResult)
 
+    let outputFilePath = inputFile.getPathInPackage();
+    // Meteor will error when loading .vue files on the server unless they are postfixed with .js
+    if (inputFile.getArch().indexOf('os') === 0 && inputFilePath.indexOf('node_modules') !== -1) {
+      outputFilePath += '.js';
+    }
+
+    // Including the source maps for .vue files from node_modules breaks source mapping. 
+    const sourceMap = inputFilePath.indexOf('node_modules') === -1
+      ? compileResult.map
+      : undefined;
+
     // Add JS Source file
     inputFile.addJavaScript({
-      path: inputFile.getPathInPackage(),
+      path: outputFilePath,
       data: js,
-      sourceMap: compileResult.map,
+      sourceMap: sourceMap,
       lazy: false,
     });
 

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -621,7 +621,7 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
   js += `__vue_options__.packageName = '${inputFile.getPackageName()}';`;
 
   // Export
-  js += `module.export('default', exports.default = __vue_script__);`;
+  js += `module.export('default', exports.default = __vue_script__);exports.__esModule = true;`;
 
   if (!isHotReload) {
     // Hot-reloading


### PR DESCRIPTION
There are quite a few Vue packages on npm where the author doesn't provide a compiled version. This change allows users to load `.vue` files from npm packages, e.g. `import Dropdown from 'vue-my-dropdown';`.
Without this, attempting to import a .vue file from an npm package causes the following error:
```
C:\projects\oss\tests\vue-component-test\node_modules\vue-my-dropdown\src\vue-my-dropdown.vue:1
(function (exports, require, module, __filename, __dirname) { <template>
                                                              ^
SyntaxError: Unexpected token <
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at npmRequire (C:\projects\oss\tests\vue-component-test\.meteor\local\build\programs\server\npm-require.js:133:10)
    at Module.useNode (packages\modules-runtime.js:687:18)
    at fileEvaluate (packages\modules-runtime.js:332:20)
```

The second commit fixes an issue with esModule detection (Meteor modules use a esModule symbol but most transpiled modules are looking for a simple `__esModule` property). In combination with the above, this enables the use of packages such as `vue-progressbar` (#177). 

An example project (not including the `vue-component`) can be found here: https://github.com/nathantreid/vue-component-test/tree/load-vue-component-from-npm.
If you're good with this change I can also update the npm section of the vue-component documentation.