### PR TITLE
Re-hotfix HMR port handling

### DIFF
--- a/packages/vue-component-dev-server/server/main.js
+++ b/packages/vue-component-dev-server/server/main.js
@@ -53,4 +53,4 @@ const DEVURL = process.env.HMR_URL || process.env.VUE_DEV_SERVER_URL || getLocal
 
 
 // Client-side config
-__meteor_runtime_config__.VUE_DEV_SERVER_URL = `${DEVURL}:${PORT}`
+__meteor_runtime_config__.VUE_DEV_SERVER_URL = DEVURL.indexOf(':') === -1 ? `${DEVURL}:${PORT}` : DEVURL


### PR DESCRIPTION
In one of your recent commits (https://github.com/meteor-vue/vue-meteor/commit/6c5e5ec20798f2d8d880ea5d6d6632d978426db6#diff-26959cdce8f9e9ec2e07c0bac6066129L27), an important feature was rolled back (the ability to control hmr port on the client independently of the server). That feature is essential for single-server setups behind nginx. I've encountered a problem running your demo (https://github.com/meteor-vue/vue-meteor-demo/issues/8) and found a solution: reapply one line from a previous commit (https://github.com/meteor-vue/vue-meteor/commit/e4fbd6a2fde17d368baeb6e2bb3d23d71931edce). It works fine on my server, and since it was already commited by you it should be well-tested. I would be really grateful if you could merge that line back into the project. 

By the way, thanks a lot for an awesome project! I'm really excited to make an app with vue and meteor)