### PR TITLE
Refactor vue-coffee

### DIFF
--- a/packages/vue-coffee/package.js
+++ b/packages/vue-coffee/package.js
@@ -1,23 +1,15 @@
 Package.describe({
   name: 'akryum:vue-coffee',
-  version: '0.0.5',
+  version: '0.1.0',
   summary: 'Add coffee support for vue components',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md'
 });
 
 Package.registerBuildPlugin({
-  name: "vue-component-coffee",
-  use: [
-    'ecmascript@0.4.4'
-  ],
-  sources: [
-    'vue-coffee.js'
-  ],
-  npmDependencies: {
-    'coffeescript': '1.12.6',
-    'source-map': '0.5.6'
-  }
+  name: 'vue-component-coffee',
+  use: ['ecmascript@0.8.2', 'coffeescript-compiler@1.12.7_1'],
+  sources: ['vue-coffee.js']
 });
 
 Package.onUse(function(api) {

--- a/packages/vue-coffee/vue-coffee.js
+++ b/packages/vue-coffee/vue-coffee.js
@@ -1,130 +1,26 @@
-// Used some code from https://github.com/meteor/meteor/blob/devel/packages/coffeescript/plugin/compile-coffeescript.js
+import { Meteor } from 'meteor/meteor';
+import { CoffeeScriptCompiler } from 'meteor/coffeescript-compiler';
 
-global.vue = global.vue || {}
-global.vue.lang = global.vue.lang || {}
+const coffeeScriptCompiler = new CoffeeScriptCompiler();
 
+global.vue = global.vue || {};
+global.vue.lang = global.vue.lang || {};
 
-import sourcemap from 'source-map';
-import coffee from 'coffeescript';
-import {
-  ECMAScript
-} from 'meteor/ecmascript';
-import {
-  Meteor
-} from 'meteor/meteor';
+global.vue.lang.coffee = Meteor.wrapAsync(function({ source, inputFile }, callback) {
+  // Override this method so that it returns only the source within the <script> tags.
+  inputFile.getContentsAsString = function() {
+    return source;
+  }
+  // Make sure CoffeeScriptCompiler doesn’t think that this is Literate CoffeeScript.
+  inputFile.getExtension = function() {
+    return 'coffee';
+  }
 
-global.vue.lang.coffee = Meteor.wrapAsync(function({
-  source,
-  inputFile
-}, cb) {
+  const sourceWithMap = coffeeScriptCompiler.compileOneFile(inputFile);
 
-  const compileOptions = {
-    bare: true,
-    filename: inputFile.getPathInPackage(),
-    // Return a source map.
-    sourceMap: true,
-    // Include the original source in the source map (sourcesContent field).
-    inline: true,
-    // This becomes the "file" field of the source map.
-    generatedFile: "/" + outputFilePath(inputFile),
-    // This becomes the "sources" field of the source map.
-    sourceFiles: [inputFile.getDisplayPath()]
-  };
-
-  let output = coffee.compile(source, compileOptions);
-
-  try {
-    output.js = ECMAScript.compileForShell(output.js);
-  } catch (e) {}
-
-  const stripped = stripExportedVars(
-    output.js,
-    inputFile.getDeclaredExports().map(e => e.name));
-  const sourceWithMap = addSharedHeader(
-    stripped, JSON.parse(output.v3SourceMap));
-
-  cb(null, {
+  callback(null, {
     script: sourceWithMap.source,
     map: sourceWithMap.sourceMap,
     useBabel: false
   });
 });
-
-
-function outputFilePath(inputFile) {
-  return inputFile.getPathInPackage() + ".js";
-}
-
-function stripExportedVars(source, exports) {
-  if (!exports || !exports.length)
-    return source;
-  const lines = source.split("\n");
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const match = /^var (.+)([,;])$/.exec(line);
-    if (!match)
-      continue;
-
-    // If there's an assignment on this line, we assume that there are ONLY
-    // assignments and that the var we are looking for is not declared. (Part
-    // of our strong assumption about the layout of this code.)
-    if (match[1].indexOf('=') !== -1)
-      continue;
-
-    // We want to replace the line with something no shorter, so that all
-    // records in the source map continue to point at valid
-    // characters.
-    function replaceLine(x) {
-      if (x.length >= lines[i].length) {
-        lines[i] = x;
-      } else {
-        lines[i] = x + new Array(1 + (lines[i].length - x.length)).join(' ');
-      }
-    }
-
-    let vars = match[1].split(', ').filter(v => exports.indexOf(v) === -1);
-    if (vars.length) {
-      replaceLine("var " + vars.join(', ') + match[2]);
-    } else {
-      // We got rid of all the vars on this line. Drop the whole line if this
-      // didn't continue to the next line, otherwise keep just the 'var '.
-      if (match[2] === ';')
-        replaceLine('');
-      else
-        replaceLine('var');
-    }
-    break;
-  }
-
-  return lines.join('\n');
-}
-
-function addSharedHeader(source, sourceMap) {
-  // This ends in a newline to make the source map easier to adjust.
-  const header = ("__coffeescriptShare = typeof __coffeescriptShare === 'object' " +
-    "? __coffeescriptShare : {}; " +
-    "var share = __coffeescriptShare;\n");
-
-  // If the file begins with "use strict", we need to keep that as the first
-  // statement.
-  const processedSource = source.replace(/^(?:((['"])use strict\2;)\n)?/, (match, useStrict) => {
-    if (match) {
-      // There's a "use strict"; we keep this as the first statement and insert
-      // our header at the end of the line that it's on. This doesn't change
-      // line numbers or the part of the line that previous may have been
-      // annotated, so we don't need to update the source map.
-      return useStrict + "  " + header;
-    } else {
-      // There's no use strict, so we can just add the header at the very
-      // beginning. This adds a line to the file, so we update the source map to
-      // add a single un-annotated line to the beginning.
-      sourceMap.mappings = ";" + sourceMap.mappings;
-      return header;
-    }
-  });
-  return {
-    source: processedSource,
-    sourceMap: sourceMap
-  };
-}


### PR DESCRIPTION
See https://github.com/meteor/meteor/pull/8960 / https://github.com/meteor/meteor/pull/9018

This PR refactors the `vue-coffee` package to use the new Meteor `coffeescript-compiler` package, which is the “compilation” part of the old Meteor `coffeescript` package split apart from the “build compiler plugin” part. `vue-coffee` using `coffeescript-compiler` lets `vue-coffee` avoid needing to fork the old Meteor `coffeescript` package, and lets `vue-coffee` shrink down to just a few lines of code. This also positions `vue-coffee` to easily respond to new upstream versions of `coffeescript-compiler` (most likely by bumping a dependency version number, with no other changes).