### PR TITLE
vue-component: avoid finding and replacing ‘export default’

### DIFF
--- a/packages/vue-coffee/README.md
+++ b/packages/vue-coffee/README.md
@@ -15,7 +15,7 @@ This meteor package adds [CoffeeScript](http://coffeescript.org/) support in you
 <script lang="coffee">
 import { Meteor } from 'meteor/meteor'
 
-return
+export default
   props: [ 'data' ]
   methods:
     removePost: ->

--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-component',
-  version: '0.10.5',
+  version: '0.10.6',
   summary: 'VueJS single-file components that hot-reloads',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md'

--- a/packages/vue-component/plugin/regexps.js
+++ b/packages/vue-component/plugin/regexps.js
@@ -1,5 +1,3 @@
-jsImportsReg = /import\s+.+\s+from\s+.+;?\s*/g;
-jsExportDefaultReg = /export\s+default/g;
 quoteReg = /'/g;
 lineReg = /\r?\n|\r/g;
 tagReg = /<([\w\d-]+)((\s+.*?)*)?\/?>/ig;

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -160,7 +160,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       }
 
       // Export
-      script = script.replace(jsExportDefaultReg, 'return');
+      script += `\nreturn require('${this.inputFile.getDisplayPath()}').default;`
 
       // Babel
       if(useBabel) {
@@ -226,7 +226,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       map.names = lastMap.names
       map.file = this.inputFile.getPathInPackage()
 
-      js += '__vue_script__ = (function(){' + script + '\n})();';
+      js += '__vue_script__ = (function(){ ' + script + '\n})();';
     }
 
     // Template

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -556,7 +556,7 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
   const isDev = isDevelopment();
   const inputFilePath = inputFile.getPathInPackage();
 
-  let js = 'var __vue_script__, __vue_template__;' + compileResult.code;
+  let js = 'var __vue_script__, __vue_template__; ' + compileResult.code + '\n';
   js += `__vue_script__ = __vue_script__ || {};`;
   js += `var __vue_options__ = (typeof __vue_script__ === "function" ?
   (__vue_script__.options || (__vue_script__.options = {}))


### PR DESCRIPTION
Fixes #165, at least for projects that use `vue-component` (and not the `vue-router` or `vue-router2` Meteor packages, which aren’t used by [vue-meteor-demo](https://github.com/meteor-vue/vue-meteor-demo); I guess the recommended practice now is to use the NPM `vue-router` and not those Meteor packages?).

This PR uses proper module syntax to return modules’ scripts as the scripts for those components. Previously, `vue-component` was doing a find-and-replace on the source code for those components’ scripts, replacing `export default` with `return` before compiling the code. This is unsafe, to say the least, and also incompatible with any code that has already passed through Babel before reaching `vue-component` (such as code processed by `vue-coffee`). Now an extra line is appended to the bottom of the script, with code like:

```js
return require('/src/imports/ui/GoogleMap.vue').default;
```
This is backward-compatible with the workaround for `vue-coffee` mentioned in #165, where `return` was used at the top in place of `export default`; that still works, though now we can follow recommended Vue style and use `export default` instead. CommonJS syntax (`exports.default =`) also works.