### PR TITLE
Handle file renames properly for Vue components and routes files

### DIFF
--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -126,7 +126,11 @@ VueComponentCompiler = class VueCompo extends CachingCompiler {
 
   getCacheKey(inputFile) {
     let cache = Cache.getCache(inputFile)
-    return inputFile.getSourceHash() + '_' + cache.dependencyManager.lastChangeTime
+    return [
+      inputFile.getSourceHash(),
+      inputFile.getPathInPackage(),
+      cache.dependencyManager.lastChangeTime
+    ]
   }
 
   compileResultSize(compileResult) {

--- a/packages/vue-router/plugin/plugin.js
+++ b/packages/vue-router/plugin/plugin.js
@@ -14,7 +14,10 @@ class VueRouterCompiler extends CachingCompiler  {
   }
 
   getCacheKey(inputFile) {
-    return inputFile.getSourceHash();
+    return [
+      inputFile.getSourceHash(),
+      inputFile.getPathInPackage()
+    ];
   }
 
   compileResultSize(compileResult) {

--- a/packages/vue-router2/plugin/plugin.js
+++ b/packages/vue-router2/plugin/plugin.js
@@ -13,7 +13,10 @@ class VueRouterCompiler extends CachingCompiler {
   }
 
   getCacheKey (inputFile) {
-    return inputFile.getSourceHash()
+    return [
+      inputFile.getSourceHash(),
+      inputFile.getPathInPackage()
+    ]
   }
 
   compileResultSize (compileResult) {


### PR DESCRIPTION
When renaming Vue components, the compiler gets confused because it sees a file with the same source hash and thinks it should be the same, even though it isn't. To reproduce this bug:

1. Clone https://github.com/meteor-vue/vue-meteor-demo
2. Rename `Notes.vue` to `Foo.vue` and adjust the import in `routes.js`. 
3. You will see the following error:

```
W20171209-23:39:12.527(-5)? (STDERR) Error: Cannot find module '/src/imports/ui/Notes.vue'
W20171209-23:39:12.527(-5)? (STDERR)     at makeMissingError (packages/modules-runtime.js:231:12)
W20171209-23:39:12.527(-5)? (STDERR)     at require (packages/modules-runtime.js:241:19)
W20171209-23:39:12.528(-5)? (STDERR)     at src/imports/ui/Notes.vue:22:1
W20171209-23:39:12.528(-5)? (STDERR)     at Foo.vue (src/imports/ui/Notes.vue:22:1)
W20171209-23:39:12.528(-5)? (STDERR)     at fileEvaluate (packages/modules-runtime.js:343:9)
W20171209-23:39:12.528(-5)? (STDERR)     at require (packages/modules-runtime.js:238:16)
W20171209-23:39:12.529(-5)? (STDERR)     at routes.js (src/imports/routes.js:1:311)
W20171209-23:39:12.529(-5)? (STDERR)     at fileEvaluate (packages/modules-runtime.js:343:9)
W20171209-23:39:12.529(-5)? (STDERR)     at require (packages/modules-runtime.js:238:16)
W20171209-23:39:12.529(-5)? (STDERR)     at app.js (src/imports/app.js:1:750)
```

These changes fix the error and allows the new file to be referenced properly, and thus fixes #258. Hope to see it merged in soon!

Comments: 
- I looked at other dependents of [`caching-compiler`](https://atmospherejs.com/meteor/caching-compiler), specifically how Meteor implemented their Coffeescript compiler, to make these changes. Relevant files are the following:

> https://github.com/meteor/meteor/blob/master/packages/non-core/coffeescript/compile-coffeescript.js
> https://github.com/meteor/meteor/blob/master/packages/non-core/coffeescript-compiler/coffeescript-compiler.js

- I am not sure what `cache.dependencyManager.lastChangeTime` is doing in the code; as far as I can tell it was added for the ability to watch imports ( [commit](https://github.com/meteor-vue/vue-meteor/commit/d7d71f77f87697f7e6a3bb32dca624888d5774ea) ). It seems, however, that this is what [`multi-file-caching-compiler`](https://github.com/meteor/meteor/blob/devel/packages/caching-compiler/multi-file-caching-compiler.js) was built for. Maybe revisit this part instead of rolling your own? It's not clear to me that it is necessary.
- I've noticed some weird behavior with `.routes.js` files before in the past as well so added paths there too. Since routes files are not imported by other files it shouldn't cause problems if the contents haven't changed, but it can't hurt.