### PR TITLE
Update babel-compiler for Meteor 1.6.1 compatibility

### DIFF
--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
   use: [
     'ecmascript@0.6.1',
     'caching-compiler@1.1.9',
-    'babel-compiler@6.13.0',
+    'babel-compiler@7.0.0',
     'templating-tools@1.1.2',
   ],
   sources: [

--- a/packages/vue-router2/package.js
+++ b/packages/vue-router2/package.js
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
   use: [
     'ecmascript@0.4.4',
     'caching-compiler@1.0.5',
-    'babel-compiler@6.8.0',
+    'babel-compiler@7.0.0',
   ],
   sources: [
     'plugin/plugin.js',


### PR DESCRIPTION
Updates the babel-compiler package as required to support Meteor 1.6.1. Fixes #290.