### PR TITLE
CSS modules changes to allow plugins more control

### DIFF
--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -380,17 +380,12 @@ VueComponentTagHandler = class VueComponentTagHandler {
                 inputFile: this.inputFile,
                 dependencyManager: this.dependencyManager,
                 tag: styleTag,
+                cssModules,
               })
               // console.log('Css result', result)
               css = result.css
               cssMap = result.map
-              if (result.cssModules) {
-                const moduleName = typeof styleTag.attribs.module === 'string' ? styleTag.attribs.module : defaultModuleName
-                if (cssModules === undefined) {
-                  cssModules = {}
-                }
-                cssModules[moduleName] = { ...(cssModules[moduleName] || {}), ...result.cssModules }
-              }
+              cssModules = result.cssModules
               if (result.js) {
                 js += result.js
               }
@@ -446,6 +441,13 @@ VueComponentTagHandler = class VueComponentTagHandler {
           map: cssMap
         })
       }
+    }
+
+    if (cssModules && !global.vue.cssModules) {
+      cssModules = Object.keys(cssModules).reduce((result, key) => {
+        result[key] = JSON.stringify(cssModules[key]);
+        return result;
+      }, {});
     }
 
     let compileResult = {

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -631,7 +631,7 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
   if(compileResult.cssModules) {
     const modules = Object.keys(compileResult.cssModules)
     const modulesCode = '__vue_options__.computed = __vue_options__.computed || {};\n' +
-      modules.map(module=>`__vue_options__.computed['${module}'] = function() {\n return ${JSON.stringify(compileResult.cssModules[module])}\n};\n`).join('\n')
+      modules.map(module=>`__vue_options__.computed['${module}'] = function() {\n return ${compileResult.cssModules[module]}\n};\n`).join('\n')
     js += modulesCode
     // console.log(modulesCode)
   }


### PR DESCRIPTION
CSS modules changes to allow plugins more control

This PR does 2 things:
1. `tag-handler.js` lines 383 - 388 and `vue-compiler.js`: grants CSS modules plugins (i.e. my plugin 😄) the ability to fully control the CSS modules output. Previously, this output was being run through `JSON.stringify` in the compiler, now it's being output directly. This is important for me because the lastest version of my CSS modules plugin has the ability to output a `Proxy` object that displays a helpful error message if the developer attempts to use a class that doesn't exist.
2. `tag-handler.js` lines 446-452: updates the built-in CSS modules code so it still works (no functional changes).