### PR TITLE
Hot reload fixes

### DIFF
--- a/packages/vue-component-dev-client/client/vue2-hot.js
+++ b/packages/vue-component-dev-client/client/vue2-hot.js
@@ -201,7 +201,7 @@ exports.reload = tryWrap((id, options) => {
         // preserve pre 2.2 behavior for global mixin handling
         record.Ctor.extendOptions = options
       }
-      const newCtor = record.Ctor.super.extend(options)
+      const newCtor = (record.Ctor.super || record.Ctor).extend(options)
       record.Ctor.options = newCtor.options
       record.Ctor.cid = newCtor.cid
       record.Ctor.prototype = newCtor.prototype

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -114,7 +114,6 @@ VueComponentTagHandler = class VueComponentTagHandler {
       }
 
       // Export
-      script += `\nreturn require('${this.inputFile.getDisplayPath()}').default`
 
       // Babel
       if (useBabel) {
@@ -180,7 +179,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       map.names = lastMap.names
       map.file = this.inputFile.getPathInPackage()
 
-      js += '__vue_script__ = (function(){ ' + script + '\n})()'
+      js += 'module.exportDefault = function(value) { __vue_script__ = value; }; (function(){ if (!module.watch) {console.log(\'module\', module);} ' + script + '\n})();'
     }
 
     // Template

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -342,8 +342,8 @@ class ComponentWatcher {
           this.refresh()
         }
       }, 100, {
-        leading: true,
-        trailing: false,
+        leading: false,
+        trailing: true,
       }))
       this.watcher.on('error', (error) => console.error(error))
     }


### PR DESCRIPTION
We've been experiencing hot reload issues for a while, but I hadn't gotten around to reporting it or looking into it. Anyways, there are 2 issues:
1. Sometimes changes don't hot reload and cause the page to refresh instead; (probably #294 and 291)
2. Changes to the script or CSS modules cause the error `Template or render function not defined` (#254)

I dove into it today and now have hot reloads working flawlessly, at least in my limited tests.

Issue 1 is seems to be caused by the change event firing before the file is finished being written. When [the file is read](https://github.com/meteor-vue/vue-meteor/blob/master/packages/vue-component/plugin/vue-compiler.js#L355) sometimes `contents` would be empty, which would then cause HMR to fail and the page would refresh. In my digging, I discovered various references to similar issues (such as https://github.com/nodejs/node/issues/6112). In my case I'm using WebStorm with safe aka atomic writes turned off, so WebStorm is writing directly to the file. I switched the `debounce` from `leading` to `trailing` so that there is always a brief delay after the change events are finished before the file is read.
Issue 1 is addressed by the `always delay file refresh by at least 100 ms` commit.

Issue 2 is caused by the `module.exportDefault` call that the `export default { }` syntax is automatically transformed into. I think this is because the object passed to `module.exportDefault` [isn't allowed to change](https://github.com/benjamn/reify/blob/master/README.md#moduleexportgetters), so [the `module.runSetters(eval(js))` call](https://github.com/meteor-vue/vue-meteor/blob/master/packages/vue-component-dev-client/client/dev-client.js#L125) - the `eval(js)` call gets transformed into `module.runSetters(eval(js))` - always returns the value of that first `module.exportDefault` instead of the one from [the final export](https://github.com/meteor-vue/vue-meteor/blob/master/packages/vue-component/plugin/vue-compiler.js#L674).
Issue 2 is addressed by the `mask module.exportDefault to prevent reload issues` and `handle root component changes` commits. I had to add the second commit to handle cases [like this one](https://github.com/nathantreid/meteor-vue-hmr-issues/blob/master/client/main.js#L6).

Sample repo I used for testing is here: https://github.com/nathantreid/meteor-vue-hmr-issues/blob/master/client/main.js#L6.

Screen caps of the issues:

**Issue 1**
![hmr-issue-1](https://user-images.githubusercontent.com/1229110/35605866-5223f156-0611-11e8-92ee-93304407e67c.gif)

**Issue 2**
![hmr-issue-2](https://user-images.githubusercontent.com/1229110/35605868-56643fbe-0611-11e8-9d08-b434b2825387.gif)

**After both fixes**
![hmr-issues-both-fixes](https://user-images.githubusercontent.com/1229110/35605913-9ab3a09c-0611-11e8-895b-dd93365fffee.gif)
