### PR TITLE
Add head and body append to vue-ssr createApp

### DIFF
--- a/packages/vue-ssr/server/index.js
+++ b/packages/vue-ssr/server/index.js
@@ -123,10 +123,18 @@ onPageLoad(sink => new Promise((resolve, reject) => {
               // })
               // // sink.appendToHead(`<script type="text/inject-data">${encodeURIComponent(injectData)}</script>`)
 
-              const script = (result.js && `<script type="text/javascript">${result.js}</script>`) || ''
+              let appendHtml
+              if (typeof result.appendHtml === "function") appendHtml = result.appendHtml()
+
+              const head = ((appendHtml && appendHtml.head) || result.head) || ''
+              const body = ((appendHtml && appendHtml.body) || result.body) || ''
+              const js = ((appendHtml && appendHtml.js) || result.js) || ''
+
+              const script = js && `<script type="text/javascript">${js}</script>`
 
               sink.renderIntoElementById(VueSSR.outlet, html)
-              sink.appendToBody(script)
+              sink.appendToHead(head)
+              sink.appendToBody([body, script])
 
               resolve()
             },


### PR DESCRIPTION
It is currently impossible to append html to `head` or `body` tags using vue-ssr package's `VueSSR.createApp`. In order to allow packages such as [vue-meta](https://github.com/declandewet/vue-meta#step-22-populating-the-document-meta-info-with-inject) to work in SSR, I have made these changes:

- Added the possibility of returning `head` and `body` strings (along with `js` and `app`) which will be appended to their respective tag.
- Added the possibility of returning an `appendHtml` callback allowing to create `head`, `body` or `js` strings after the renderer as generated the app. This is required with [vue-meta](https://github.com/declandewet/vue-meta#step-22-populating-the-document-meta-info-with-inject) which only returns meta once the app as been rendered.

Here is an example of what would be possible with these changes:

```javascript
VueSSR.createApp = function (context) {
  return new Promise((resolve, reject) => {
    const { app, router, store } = createApp()

    router.push(context.url)
    context.meta = app.$meta()

    // ...

    resolve({
      app,
      appendHtml() {
        const {
          title, link, style, script, noscript, meta
        } = context.meta.inject()

        return {
          head: `
            ${meta.text()}
            ${title.text()}
            ${link.text()}
            ${style.text()}
            ${script.text()}
            ${noscript.text()}
          `,
          body: script.text({ body: true })
        }
      }
    })
  })
}
```

Partially fixes #149. As far as I know, Meteor doesn't allow `html` or `body` attributes to be edited on the server.