### PR TITLE
Update hacky import for meteor-node-stubs 0.3.3

### DIFF
--- a/packages/vue-component-dev-client/client/dev-client.js
+++ b/packages/vue-component-dev-client/client/dev-client.js
@@ -6,7 +6,7 @@ import { Autoupdate } from 'meteor/autoupdate'
 import VueHot1 from './vue-hot'
 import VueHot2 from './vue2-hot'
 // Hack https://github.com/socketio/socket.io-client/issues/961
-import Response from 'meteor-node-stubs/node_modules/http-browserify/lib/response'
+import Response from 'meteor-node-stubs/node_modules/https-browserify/lib/response'
 
 const tagStyle = 'padding: 2px 4px 1px; background: #326ABC; color: white; border-radius: 3px; font-weight: bold;'
 const infoStyle = 'font-style: italic; color: #326ABC;'


### PR DESCRIPTION
Not sure if this is a hack you even want to keep around, but just FYI. It's now `https-browserify` instead of `http-browserify`. Otherwise we get this error:

![image](https://user-images.githubusercontent.com/2080084/38269978-04779726-3750-11e8-8610-036613c67f1a.png)

See https://github.com/meteor/node-stubs/commit/789b8ff81c21546a280a7bfbb56764dd6e9c0fce