### PR TITLE
Add custom context so that one can identify this configuration

### DIFF
--- a/packages/vue-component/plugin/post-css.js
+++ b/packages/vue-component/plugin/post-css.js
@@ -8,7 +8,7 @@ let loaded
 loadPostcssConfig = Meteor.wrapAsync(function (cb) {
   let error = null
   if (!loaded) {
-    loaded = load().catch(err => {
+    loaded = load({'vue-meteor': true}).catch(err => {
       // postcss-load-config throws error when no config file is found,
       // but for us it's optional. only emit other errors
       if (err.message.indexOf('No PostCSS Config found') < 0) {


### PR DESCRIPTION
You can then use `ctx` in a function to know if you have to return configuration for Vue PostCSS or some other: https://github.com/michael-ciniawsky/postcss-load-config#postcssconfigjs-or-postcssrcjs