### PR TITLE
Fix to prevent infinate reloading of clientside and to make HMR work again 

### DIFF
--- a/packages/vue-component-dev-client/client/dev-client.js
+++ b/packages/vue-component-dev-client/client/dev-client.js
@@ -71,7 +71,7 @@ function reload (options) {
 // Reimplement client version check from autoupdate package
 function checkNewVersionDocument (doc) {
   if (doc._id === 'version' && doc.version !== autoupdateVersion) {
-    reload()
+    // reload()
   }
 }
 var autoupdateVersion = __meteor_runtime_config__.autoupdateVersion || `unknown`

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -328,22 +328,14 @@ class ComponentWatcher {
   }
 
   _watchPath (filePath) {
-    if (!this.watcher || filePath !== this.filePath) {
-      this.filePath = filePath
-      // Fast file change detection
-      this._closeWatcher()
-      this.watcher = fs.watch(filePath, {
-        persistent: false,
-      }, _.debounce(event => {
-        if (event === 'change') {
-          this.refresh()
-        }
-      }, 100, {
-        leading: false,
-        trailing: true,
-      }))
-      this.watcher.on('error', (error) => console.error(error))
-    }
+    this.filePath = filePath
+    // Fast file change detection
+    this._closeWatcher()
+    this.watcher = fs.watch(filePath, {
+      persistent: false,
+    })
+    this.watcher.on('change', () => this.refresh())
+    this.watcher.on('error', (error) => console.error(error))
   }
 }
 


### PR DESCRIPTION
I'm not an expert (yet hehe) with HMR, but I manage to 'fix' the infinate reload bug by switching off the reload override in the vue-component-dev-client package. Unfortunately this exposed another problem, which was that the HMR client wasnt getting any updates (read "was not working"). I've managed to fix that aswell, but I might have skipped some optimisations which we can build in later again.

#332 