### PR TITLE
Fixed #326 and updated Meteor packages

### DIFF
--- a/packages/vue-component-dev-client/client/dev-client.js
+++ b/packages/vue-component-dev-client/client/dev-client.js
@@ -70,11 +70,13 @@ function reload (options) {
 
 // Reimplement client version check from autoupdate package
 function checkNewVersionDocument (doc) {
-  if (doc._id === 'version' && doc.version !== autoupdateVersion) {
-    reload()
+  if (doc && doc.version && doc._id && __meteor_runtime_config__.autoupdate.versions[doc._id]) {
+    if (__meteor_runtime_config__.autoupdate.versions[doc._id].version !== doc.version) {
+      reload()
+    }
   }
 }
-var autoupdateVersion = __meteor_runtime_config__.autoupdateVersion || `unknown`
+
 var ClientVersions = Autoupdate._ClientVersions
 if (ClientVersions) {
   ClientVersions.find().observe({

--- a/packages/vue-component-dev-client/package.js
+++ b/packages/vue-component-dev-client/package.js
@@ -8,9 +8,9 @@ Package.describe({
 })
 
 Package.onUse(function (api) {
-  api.use('ecmascript@0.11.1')
+  api.use('ecmascript@0.12.1')
   api.use('reload@1.2.0')
-  api.use('autoupdate@1.4.0')
+  api.use('autoupdate@1.5.0')
   api.use('reactive-var@1.0.11')
   api.mainModule('client/dev-client.js', 'client')
 })

--- a/packages/vue-component-dev-server/package.js
+++ b/packages/vue-component-dev-server/package.js
@@ -8,7 +8,7 @@ Package.describe({
 })
 
 Package.onUse(function (api) {
-  api.use('ecmascript@0.11.1')
-  api.use('webapp@1.6.0')
+  api.use('ecmascript@0.12.1')
+  api.use('webapp@1.7.0')
   api.mainModule('server/main.js', 'server')
 })

--- a/packages/vue-component/README.md
+++ b/packages/vue-component/README.md
@@ -13,6 +13,14 @@ meteor add akryum:vue-component
 
 ## Usage
 
+### Babel cache
+
+The babel cache folder defaults to `.cache`, but you can override it with the `BABEL_CACHE_DIR` environment variable:
+
+```
+cross-env BABEL_CACHE_DIR=cacheFolderName
+```
+
 ### Hot-reloading
 
 To enable component hot-reloading, make sure that you launch meteor in development mode (typically with `meteor` or `meteor run`). The server console should print this line:

--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -9,9 +9,9 @@ Package.describe({
 Package.registerBuildPlugin({
   name: 'vue-component',
   use: [
-    'ecmascript@0.11.1',
-    'caching-compiler@1.1.12',
-    'babel-compiler@7.1.1',
+    'ecmascript@0.12.1',
+    'caching-compiler@1.2.0',
+    'babel-compiler@7.2.1',
     'templating-tools@1.1.2',
   ],
   sources: [

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -16,6 +16,9 @@ function toFunction (code) {
 // Cache
 global._vue_cache = global._vue_cache || {}
 
+// Babel cache directory
+process.env.BABEL_CACHE_DIR = process.env.BABEL_CACHE_DIR || '.cache'
+
 const babelOptions = Babel.getDefaultOptions()
 
 // Compiler


### PR DESCRIPTION
- Updated the meteor packages to align with the 1.8 release
- Fixed the continuous reloading issue present in "vue-component-dev-client"
- Added a default babel cache folder value to "process.env.BABEL_CACHE_DIR" so Meteor no longer shows the corresponding warning