### PR TITLE
Config Option for other .scss/.sass import paths.

### DIFF
--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -18,15 +18,27 @@ function resolveImport (dependencyManager) {
       let currentDirectory = path.dirname(prev === 'stdin' ? this.options.outFile : prev)
       resolvedFilename = path.resolve(currentDirectory, url)
     }
+    const importPaths = [ resolvedFilename ]
+    const pjson = require("package.json") // can not be moved outside. Reqired here to get the package.json of the project that is being run
 
-    resolvedFilename = discoverImportPath(resolvedFilename)
-    if (resolvedFilename === null) {
+    try {
+      // get the package.json config option and create paths for the requested file.
+      pjson.vue.css.loaderOptions.sass.includePaths.forEach( (str) => {
+        importPaths.push(path.resolve(str, url))
+      })
+    } catch (e) {
+      // Ignore error. package.json option is not set.
+    }
+
+    const resolvedNames = importPaths.map( discoverImportPath ).filter((fileName) => fileName !== null && typeof fileName !== "undefined");
+
+    if (resolvedNames.length < 1) {
       done(new Error('Unknown import (file not found): ' + url))
     } else {
-      dependencyManager.addDependency(resolvedFilename)
+      dependencyManager.addDependency(resolvedNames[0])
 
       done({
-        file: resolvedFilename,
+        file: resolvedNames[0],
       })
     }
   }
@@ -44,7 +56,7 @@ function discoverImportPath (importPath) {
   }
 
   for (let i = 0, potentialPath = potentialPaths[i]; i < potentialPaths.length; i++, potentialPath = potentialPaths[i]) {
-    if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
+	if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
       return potentialPath
     }
   }

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -56,7 +56,7 @@ function discoverImportPath (importPath) {
   }
 
   for (let i = 0, potentialPath = potentialPaths[i]; i < potentialPaths.length; i++, potentialPath = potentialPaths[i]) {
-	if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
+  if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
       return potentialPath
     }
   }

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -56,7 +56,7 @@ function discoverImportPath (importPath) {
   }
 
   for (let i = 0, potentialPath = potentialPaths[i]; i < potentialPaths.length; i++, potentialPath = potentialPaths[i]) {
-  if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
+    if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
       return potentialPath
     }
   }


### PR DESCRIPTION
Some Packages (for example the `@material/button` packge) has imports relative to node_modules.
These imports previusly failded, because there was no possibility to load these sub-imports.

For the package.json-file:
Add a new snippet like this:
```json
"vue": {
  "css": {
    "loaderOptions": {
      "sass": {
        "includePaths": [
          "node_modules"
        ],
      }
    }
  }
},
```

Fixes #246
Fixes #301 
(hopefully)

_this is my first pull-request, so please check carefully and tell me what i've done wrong_