### PR TITLE
Generate meaningful CSS Modules class names

### DIFF
--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -358,9 +358,10 @@ VueComponentTagHandler = class VueComponentTagHandler {
                 if (cssModules === undefined) { cssModules = {} }
                 cssModules[moduleName] = { ...(cssModules[moduleName] || {}), ...json }
               },
-              generateScopedName (exportedName, filePath) {
-                return `vue-module-${Hash(filePath)}-${Hash(exportedName)}`
-              },
+              
+              // Generate a class name in the form of .<vue_component_name>__<local_class_name>___<hash>
+              // Ref.: https://github.com/css-modules/postcss-modules#generating-scoped-names
+              generateScopedName: '[name]__[local]___[hash:base64:5]'
             }))
             isAsync = true
           }


### PR DESCRIPTION
Using class names in the form of `.<vue_component_name>__<local_class_name>___<hash>` (similarly to `vue-loader`) instead of `.vue-module-<hash>-<hash>` should simplify debugging a lot.