### PR TITLE
Fixes #350, makes source maps line up with the correct lines in DevTools

### DIFF
--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -536,7 +536,7 @@ function compileOneFileWithContents (inputFile, contents, parts, babelOptions) {
   try {
     const cache = Cache.getCache(inputFile)
     const compiler = loadPackage(inputFile, 'vue-template-compiler', loadDefaultTemplateCompiler)
-    const sfcDescriptor = compiler.parseComponent(contents, { pad: 'line' })
+    const sfcDescriptor = compiler.parseComponent(contents)
 
     return compileTags(inputFile, sfcDescriptor, parts, babelOptions, cache.dependencyManager)
   } catch (e) {


### PR DESCRIPTION
This one-line PR fixes #350, where the source maps are offset by the number of lines above the `<script>` opening tag:

![image](https://user-images.githubusercontent.com/456802/63914230-60ca2680-c9e7-11e9-970c-44cfb6ea51d3.png)

(Line 14 is supposed to be highlighted, not line 21. And the brighter-colored line numbers should correspond with the lines where there is source code; picture them shifted up 8 lines each.)

Once this is merged in, not only will `debugger` statements be highlighted on the proper line, but you can also just click on the line number in the gutter in DevTools to set a breakpoint on that line (you know, how it’s supposed to work). Fixes `akryum:vue-coffee` too.