### PR TITLE
Strip `~` from path when creating additional search paths

### DIFF
--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -24,7 +24,7 @@ function resolveImport (dependencyManager) {
     try {
       // get the package.json config option and create paths for the requested file.
       pkg.vue.css.sass.includePaths.forEach((str) => {
-        importPaths.push(path.resolve(str, url))
+        importPaths.push(path.resolve(str, resolvedFilename))
       })
     } catch (e) {
       // Ignore error. package.json option is not set.


### PR DESCRIPTION
If additional paths are configured in the package.json, the `~` is not stripped from the path before searching for the file.