### PR TITLE
Fix: outdated `vue-server-renderer` conflicts with newest `vue` on production

### DIFF
--- a/packages/vue-ssr/npm.json
+++ b/packages/vue-ssr/npm.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "vue": "2.2.4",
     "vue-router": "^2.3.0",
-    "vue-meteor-tracker": "^1.2.0"
+    "vue-meteor-tracker": "^1.2.0",
+    "vue-server-renderer": "^2.6.10"
   }
 }

--- a/packages/vue-ssr/package.js
+++ b/packages/vue-ssr/package.js
@@ -28,6 +28,5 @@ Package.onUse(function (api) {
 })
 
 Npm.depends({
-  'vue-server-renderer': '2.6.10',
   'cookie-parser': '1.4.4',
 })


### PR DESCRIPTION
Hello, Guillaume @Akryum.

This pull request for fixing a version mismatch of Vue and Vue Server Renderer.

## Error

```     
Vue packages version mismatch:
        
- vue@2.6.11
- vue-server-renderer@2.6.10
        
This may cause things to work incorrectly. Make sure to use the same version for both.
```

<details>
<summary>Trace</summary>

```

            at Object.<anonymous> (/built_app/programs/server/npm/node_modules/meteor/akryum_vue-ssr/node_modules/vue-server-renderer/index.js:8:9)
            at Module._compile (internal/modules/cjs/loader.js:959:30)
            at Module.Mp._compile (/built_app/programs/server/runtime.js:50:23)
            at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
            at Module.load (internal/modules/cjs/loader.js:815:32)
            at Module.Mp.load (/built_app/programs/server/runtime.js:15:31)
            at Function.Module._load (internal/modules/cjs/loader.js:727:14)
            at Module.require (internal/modules/cjs/loader.js:852:19)
            at require (internal/modules/cjs/helpers.js:74:18)
            at npmRequire (/built_app/programs/server/npm-require.js:133:12)
            at Module.useNode (packages/modules-runtime.js:664:18)
            at module (/built_app/programs/server/packages/akryum_vue-ssr.js:432:8)
            at fileEvaluate (packages/modules-runtime.js:336:7)
            at Module.require (packages/modules-runtime.js:238:14)
            at Module.moduleLink [as link] (/built_app/programs/server/npm/node_modules/meteor/modules/node_modules/reify/lib/runtime/index.js:52:22)
            at module (packages/akryum:vue-ssr/server/index.js:1:76)
            at fileEvaluate (packages/modules-runtime.js:336:7)
            at Module.require (packages/modules-runtime.js:238:14)
            at require (packages/modules-runtime.js:258:21)
            at /built_app/programs/server/packages/akryum_vue-ssr.js:468:15
            at /built_app/programs/server/packages/akryum_vue-ssr.js:475:3
            at /built_app/programs/server/boot.js:398:38
```       
</details>

## Solution

Installing `vue-server-renderer` via `akryum:npm-check` for `akryum:vue-ssr`.

Best wishes,
Sergey.