### PR TITLE
Added support of `context.headers` to Vue SSR for usage with `vue-i18n`

### DIFF
--- a/packages/vue-ssr/server/index.js
+++ b/packages/vue-ssr/server/index.js
@@ -91,7 +91,7 @@ onPageLoad(sink => new Promise((resolve, reject) => {
         // }
 
         // Vue
-        const context = { url: req.url }
+        const context = { url: req.url, headers }
         let asyncResult
         const result = VueSSR.createApp(context)
         if (result && typeof result.then === 'function') {


### PR DESCRIPTION
Hello @Akryum 

I'm added support of the `context.headers` and added example how to use it with `vue-i18n` (with injection of `<html lang>` for Meteor) and `vue-meta` packages.

Best wishes,
Sergey.