### PR TITLE
Update version of the `staringatlights:fast-render` package to 3.3.0.

### DIFF
--- a/packages/vue-ssr/package.js
+++ b/packages/vue-ssr/package.js
@@ -19,7 +19,7 @@ Package.onUse(function (api) {
     'routepolicy',
     'url',
     'akryum:npm-check@0.1.1',
-    'staringatlights:fast-render@3.2.0',
+    'staringatlights:fast-render@3.3.0',
     'ejson',
     'server-render',
   ])


### PR DESCRIPTION
Greetings, @chris-visser.

This pull-request fixes: https://github.com/meteor-vue/vue-meteor/pull/407

Best wishes,
Sergey.