### PR TITLE
fix: Default `lang` value for `script` blocks

### DIFF
--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -72,6 +72,12 @@ VueComponentTagHandler = class VueComponentTagHandler {
 
       maps.push(generateSourceMap(inputFilePath, source, script, getLineNumber(source, sfcBlock.start)))
 
+      // treating the <script> default as if it were `lang="js"`
+      // since some tools (like meteor-vuetify-loader) require to have the attribute present to work
+      if (sfcBlock.type === 'script' && !sfcBlock.lang) {
+        sfcBlock.lang = 'js';
+      }
+      
       // Lang
       if (sfcBlock.lang !== undefined) {
         let lang = sfcBlock.lang

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -75,7 +75,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       // treating the <script> default as if it were `lang="js"`
       // since some tools (like meteor-vuetify-loader) require to have the attribute present to work
       if (sfcBlock.type === 'script' && !sfcBlock.lang) {
-        sfcBlock.lang = 'js';
+        sfcBlock.lang = 'js'
       }
       
       // Lang


### PR DESCRIPTION
Some Meteor plugins require to have a `lang="js"` attribute (see https://github.com/Hernanm0g/meteor-vuetify-loader#installation)
![image](https://user-images.githubusercontent.com/601266/116456271-b3488f80-a827-11eb-88c9-4413dfad2dff.png)


But in turn, Vetur does not support this:  https://github.com/vuejs/vetur/blob/master/docs/guide/highlighting.md#syntax-highlighting

![image](https://user-images.githubusercontent.com/601266/116456222-9f049280-a827-11eb-8a65-c2ea591857a2.png)


**Vetur doc talks about highlighting syntax, but formatting code using Vetur will not work if there is a `lang="js"` for me**

TL;DR:
Figured this being the middle ground would be a good spot to make both things work (auto imports for `meteor-vuetify-loader` as well as code formatting in VScode using Vetur. 