### PR TITLE
Add Compiler reference via cpl attr in script tag

### DIFF
--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -35,7 +35,7 @@ Package.registerBuildPlugin({
     'source-map-merger': '0.2.0',
     'generate-source-map': '0.0.5',
     'autoprefixer': '9.5.1',
-    'vue-template-compiler': '2.6.11',
+    'vue-template-compiler': '2.6.12',
     'vue-template-es2015-compiler': '1.9.1',
     'colors': '1.3.3',
     'app-module-path': '2.2.0',

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -57,7 +57,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
     let inputFilePath = this.inputFile.getPathInPackage()
     let fullInputFilePath = packageName ? '/packages/' + packageName + '/' + inputFilePath : '/' + inputFilePath
     let hash = 'data-v-' + Hash(fullInputFilePath)
-
+    
     let js = ''
     let styles = []
 
@@ -72,9 +72,16 @@ VueComponentTagHandler = class VueComponentTagHandler {
 
       maps.push(generateSourceMap(inputFilePath, source, script, getLineNumber(source, sfcBlock.start)))
 
-      // Lang
-      if (sfcBlock.lang !== undefined) {
-        let lang = sfcBlock.lang
+      // Lang or compiler
+
+      // cpl is a custom compiler defined by another package
+      // Specially useful when using vscode+vetur, as the dev experience
+      // with vetur is affected is not optimal when using lang attr
+      // in script tag
+      const cpl = sfcBlock.attrs?.cpl
+      let lang = sfcBlock.lang || cpl
+
+      if (lang !== undefined) {
         try {
           let compile = global.vue.lang[lang]
           if (!compile) {


### PR DESCRIPTION
As @aczell described in PR #424, the lang attribute in <script> tag, causes some unwanted issues in vscode+vetur developer's experience. Aczell's solution works, so this PR is another way to solve the problem allowing a cpl attribute in script tag, for instance:

```javascript
<script cpl="vuetify">
```

So vue-component will check for this cpl reference and, if exists, will look for a global.vue.lang.vuetify method, and will run it as a compiler.

This will help several developers, cause when you use <script lang="js">, it breaks: File autocomplete, syntax highlighting... and some weird warning pop up.

