### PR TITLE
fix: Remove fibers from vue compiler

### DIFF
--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-component',
-  version: '1.0.0',
+  version: '0.15.2',
   summary: 'VueJS single-file components that hot-reloads',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md',

--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-component',
-  version: '0.15.2',
+  version: '1.0.0',
   summary: 'VueJS single-file components that hot-reloads',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md',

--- a/packages/vue-component/plugin/dev-server.js
+++ b/packages/vue-component/plugin/dev-server.js
@@ -77,8 +77,7 @@ if (isDevelopment()) {
       socket.emit('css', io.__styles[hash])
     }
   })
-
-  const binding = getMeteorBinding()
+  const binding = getMeteorBinding.call(this);
   PORT = parseInt(process.env.HMR_PORT) || parseInt(process.env.VUE_DEV_SERVER_PORT) || binding.port + 3 || 3003
   INTERFACE = binding.networkInterface
 

--- a/packages/vue-component/plugin/dev-server.js
+++ b/packages/vue-component/plugin/dev-server.js
@@ -77,7 +77,7 @@ if (isDevelopment()) {
       socket.emit('css', io.__styles[hash])
     }
   })
-  const binding = getMeteorBinding.call(this);
+  const binding = getMeteorBinding.call(this)
   PORT = parseInt(process.env.HMR_PORT) || parseInt(process.env.VUE_DEV_SERVER_PORT) || binding.port + 3 || 3003
   INTERFACE = binding.networkInterface
 

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -36,8 +36,8 @@ VueComponentCompiler = class VueCompo extends CachingCompiler {
 
     // console.log(`Found ${inputFiles.length} files.`)
 
-    let resolver;
-    const promise = new Promise(r => resolver = r);
+    let resolver
+    const promise = new Promise(r => resolver = r)
 
     async.eachLimit(inputFiles, this._maxParallelism, (inputFile, cb) => {
       if (!this.isIgnored(inputFile)) {
@@ -79,7 +79,7 @@ VueComponentCompiler = class VueCompo extends CachingCompiler {
       }
     }, resolver)
 
-    await promise;
+    await promise
 
     if (this._cacheDebugEnabled) {
       cacheMisses.sort()


### PR DESCRIPTION
As you may know, we're removing Fibers from Meteor, and this single use of Fibers on this package is breaking tests from Meteor tools.

I was able to test this change locally and it is working. 

Let's review it and publish the new version.

cc @Akryum 